### PR TITLE
Updating opcodes

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -9,6 +9,7 @@ CPU::CPU()
    m_log{ std::cout, __PRETTY_FUNCTION__ }
 {
     m_log.set_log_level(LOG_DEBUG);
+    // m_lineByLine = true;
 
     m_Registers.set_af(0x01B0);
     m_Registers.set_bc(0x0013);
@@ -63,18 +64,17 @@ int CPU::execute(byte_t instructionByte, bool prefixed)
         m_log(LOG_INFO) << "PC:" << +(m_PC-1) << ", Running opcode " << std::hex 
                      << ((prefixed) ? "CB_0x" : "0x") << +instructionByte  << "\n";
     }
-
     try 
     {
         if (!prefixed)
-            { return ((*this).*(instructionTable[instructionByte]))(); }
+            { return opcode_Translator(instructionByte); }
         else
             { return CBopcode_Translator(instructionByte); }
     }
     catch (std::runtime_error e)
     {
         m_log(LOG_ERROR) << e.what() << "\n";
-        // std::exit(EXIT_FAILURE);
+        std::exit(EXIT_FAILURE);
     }
 }
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -10,6 +10,7 @@ CPU::CPU()
 {
     m_log.set_log_level(LOG_DEBUG);
     // m_lineByLine = true;
+    std::cout << std::hex;
 
     m_Registers.set_af(0x01B0);
     m_Registers.set_bc(0x0013);
@@ -56,16 +57,16 @@ int CPU::cycle()
 
 int CPU::execute(byte_t instructionByte, bool prefixed)
 {
-    if(m_lineByLine)
-    {
-        m_log(LOG_INFO) << "PC:" << +(m_PC-1) << ", Running opcode " << std::hex 
-                     << ((prefixed) ? "CB_0x" : "0x") << +instructionByte  << " ";
-    }
-    else
-    {
-        m_log(LOG_INFO) << "PC:" << +(m_PC-1) << ", Running opcode " << std::hex 
-                     << ((prefixed) ? "CB_0x" : "0x") << +instructionByte  << "\n";
-    }
+    // if(m_lineByLine)
+    // {
+    //     m_log(LOG_INFO) << "PC:" << +(m_PC-1) << ", Running opcode " << std::hex 
+    //                  << ((prefixed) ? "CB_0x" : "0x") << +instructionByte  << " ";
+    // }
+    // else
+    // {
+    //     m_log(LOG_INFO) << "PC:" << +(m_PC-1) << ", Running opcode " << std::hex 
+    //                  << ((prefixed) ? "CB_0x" : "0x") << +instructionByte  << "\n";
+    // }
     try 
     {
         if (!prefixed)

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -25,14 +25,16 @@ void CPU::frameUpdate()
 
     while(cyclesThisUpdate < c_MAX_CYCLES_PER_UPDATE)
     {
-        //if (!halted) something like this
-        int cycles{ cycle() };
-        cyclesThisUpdate += cycles;
-        updateTimers(cycles);
-        // UpdateGraphics(cycles);
-        interupts();
-        if (m_lineByLine)
+        if (!halted)
+        {
+            int cycles{ cycle() };
+            cyclesThisUpdate += cycles;
+            updateTimers(cycles);
+            // UpdateGraphics(cycles);
+            if (m_lineByLine)
             getchar();
+        }
+        interupts();
     }
     m_log(LOG_ERROR) << "Frame finished!" << "\n";
     // RenderScreen();
@@ -160,12 +162,20 @@ void CPU::interupts()
                 {
                     if (testBit(enabled,i)) //and interupt (i) is enabled 
                     {
-                        //remove halt?
+                        halted = false;
                         performInterupt(i);
                     }
                 }
             }
         }
+    }
+    else if (halted)
+    {
+        byte_t requests = m_Memory.readByte(c_INTERUPTS_REQ_ADDRESS);
+        byte_t enabled = m_Memory.readByte(c_INTERUPTS_ENABLED_ADDRESS);
+
+        if (requests & enabled)
+            halted = false;
     }
 }
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -57,16 +57,6 @@ int CPU::cycle()
 
 int CPU::execute(byte_t instructionByte, bool prefixed)
 {
-    // if(m_lineByLine)
-    // {
-    //     m_log(LOG_INFO) << "PC:" << +(m_PC-1) << ", Running opcode " << std::hex 
-    //                  << ((prefixed) ? "CB_0x" : "0x") << +instructionByte  << " ";
-    // }
-    // else
-    // {
-    //     m_log(LOG_INFO) << "PC:" << +(m_PC-1) << ", Running opcode " << std::hex 
-    //                  << ((prefixed) ? "CB_0x" : "0x") << +instructionByte  << "\n";
-    // }
     try 
     {
         if (!prefixed)

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -25,7 +25,7 @@ void CPU::frameUpdate()
 
     while(cyclesThisUpdate < c_MAX_CYCLES_PER_UPDATE)
     {
-        if (!halted)
+        if (!m_Halted)
         {
             int cycles{ cycle() };
             cyclesThisUpdate += cycles;
@@ -162,20 +162,20 @@ void CPU::interupts()
                 {
                     if (testBit(enabled,i)) //and interupt (i) is enabled 
                     {
-                        halted = false;
+                        m_Halted = false;
                         performInterupt(i);
                     }
                 }
             }
         }
     }
-    else if (halted)
+    else if (m_Halted)
     {
         byte_t requests = m_Memory.readByte(c_INTERUPTS_REQ_ADDRESS);
         byte_t enabled = m_Memory.readByte(c_INTERUPTS_ENABLED_ADDRESS);
 
         if (requests & enabled)
-            halted = false;
+            m_Halted = false;
     }
 }
 

--- a/src/cpu_opcodes.cpp
+++ b/src/cpu_opcodes.cpp
@@ -126,12 +126,10 @@ void CPU::setupTables()
     //JP (HL)
     instructionTable[0xE9] = &CPU::OP_0xE9;
     // JR n
-    instructionTable[0x18] = &CPU::OP_0x18;
-    //JR cc,n
-    instructionTable[0x20] = &CPU::OP_0x20;
-    instructionTable[0x28] = &CPU::OP_0x28;
-    instructionTable[0x30] = &CPU::OP_0x30;
-    instructionTable[0x38] = &CPU::OP_0x38;
+    for (byte_t i{0x18}; i <= 0x38; i+=0x8)
+    {
+        instructionTable2[i] = &CPU::cpu_jumpRelative;
+    }
     //Calls
     //Call nn
     instructionTable[0xCD] = &CPU::OP_0xCD;
@@ -204,7 +202,8 @@ int CPU::opcode_Translator(byte_t opcode)
         (opcode>=0x80 && (opcode%8)==6) || //arithmetic
         (opcode>=0x40 && opcode<0x80 && opcode!=0x76) || //byteLoad
         (opcode<0x40 && (opcode%8)==6) || //byteLoad
-        (opcode>=0xC0 && (opcode%8)==7) //rst
+        (opcode>=0xC0 && (opcode%8)==7) || //rst
+        (opcode>=0x18 && opcode <= 0x38 && (opcode%8)==0) // Jr
     ) 
     {
         return ((*this).*(instructionTable2[opcode]))(opcode);
@@ -659,38 +658,6 @@ int CPU::OP_0xE9()
 {
     jump(JumpTest::Always, m_Registers.get_hl());
     return 4;
-}
-// JR n
-int CPU::OP_0x18()
-{
-    byte_t offset{ readNextByte() };
-    jumpRelative(JumpTest::Always, offset);
-    return 8;
-}
-//JR cc,n
-int CPU::OP_0x20()
-{
-    byte_t offset{ readNextByte() };
-    jumpRelative(JumpTest::NotZero, offset);
-    return 8;
-}
-int CPU::OP_0x28()
-{
-    byte_t offset{ readNextByte() };
-    jumpRelative(JumpTest::Zero, offset);
-    return 8;
-}
-int CPU::OP_0x30()
-{
-    byte_t offset{ readNextByte() };
-    jumpRelative(JumpTest::NotCarry, offset);
-    return 8;
-}
-int CPU::OP_0x38()
-{
-    byte_t offset{ readNextByte() };
-    jumpRelative(JumpTest::Carry, offset);
-    return 8;
 }
 //Calls
 //Call nn

--- a/src/cpu_opcodes.cpp
+++ b/src/cpu_opcodes.cpp
@@ -851,7 +851,7 @@ int CPU::OP_0x00()
 int CPU::OP_0x76()
 {
     m_log(LOG_INFO) << "Executed Halt!" << "\n";
-    halted = true;
+    m_Halted = true;
     return 4;
 }
 //STOP

--- a/src/cpu_opcodes.cpp
+++ b/src/cpu_opcodes.cpp
@@ -74,29 +74,19 @@ void CPU::setupTables()
     {
         instructionTable2[i] = &CPU::cpu_byteArithmetic;
     }
-    for (byte_t i{ 0xC6 }; i >= 0xC6; i+=0x8)
+    for (byte_t i{0xC6}; i >= 0xC6; i+=0x8)
     {
         instructionTable2[i] = &CPU::cpu_byteArithmetic;
     }
 
-    //INC n
-    instructionTable[0x3C] = &CPU::OP_0x3C;
-    instructionTable[0x04] = &CPU::OP_0x04;
-    instructionTable[0x0C] = &CPU::OP_0x0C;
-    instructionTable[0x14] = &CPU::OP_0x14;
-    instructionTable[0x1C] = &CPU::OP_0x1C;
-    instructionTable[0x24] = &CPU::OP_0x24;
-    instructionTable[0x2C] = &CPU::OP_0x2C;
-    instructionTable[0x34] = &CPU::OP_0x34;
-    //DEC n
-    instructionTable[0x3D] = &CPU::OP_0x3D;
-    instructionTable[0x05] = &CPU::OP_0x05;
-    instructionTable[0x0D] = &CPU::OP_0x0D;
-    instructionTable[0x15] = &CPU::OP_0x15;
-    instructionTable[0x1D] = &CPU::OP_0x1D;
-    instructionTable[0x25] = &CPU::OP_0x25;
-    instructionTable[0x2D] = &CPU::OP_0x2D;
-    instructionTable[0x35] = &CPU::OP_0x35;
+    for (byte_t i{0x04}; i <= 0x3C; i+=0x8)
+    {
+        instructionTable2[i] = &CPU::cpu_byteInc;
+    }
+    for (byte_t i{0x05}; i <= 0x3D; i+=0x8)
+    {
+        instructionTable2[i] = &CPU::cpu_byteDec;
+    }
     //Word arithmatic
     //ADD HL,n
     instructionTable[0x09] = &CPU::OP_0x09;
@@ -189,8 +179,9 @@ int CPU::OP_NOT_IMPLEMTED()
     throw std::runtime_error("OPCODE NOT IMPLEMENTED in table 1!");
 }
 
-int CPU::OP_NOT_IMPLEMTED2(const byte_t&)
+int CPU::OP_NOT_IMPLEMTED2(const byte_t& opcode)
 {
+    std::cout << +opcode << "\n";
     throw std::runtime_error("OPCODE NOT IMPLEMENTED in table 2!");
 }
 
@@ -203,7 +194,8 @@ int CPU::opcode_Translator(byte_t opcode)
         (opcode>=0x40 && opcode<0x80 && opcode!=0x76) || //byteLoad
         (opcode<0x40 && (opcode%8)==6) || //byteLoad
         (opcode>=0xC0 && (opcode%8)==7) || //rst
-        (opcode>=0x18 && opcode <= 0x38 && (opcode%8)==0) // Jr
+        (opcode>=0x18 && opcode <= 0x38 && (opcode%8)==0) ||// Jr
+        (opcode>=0x04 && opcode <=0x3D && ((opcode%8)==4 || (opcode%8)==5)) // Inc, Dec
     ) 
     {
         return ((*this).*(instructionTable2[opcode]))(opcode);
@@ -457,94 +449,6 @@ int CPU::OP_0xE1()
     return 12;
 }
 
-
-
-//INC n
-int CPU::OP_0x3C()
-{
-    byteINC(m_Registers.a);
-    return 4;
-}
-int CPU::OP_0x04()
-{
-    byteINC(m_Registers.b);
-    return 4;
-}
-int CPU::OP_0x0C()
-{
-    byteINC(m_Registers.c);
-    return 4;
-}
-int CPU::OP_0x14()
-{
-    byteINC(m_Registers.d);
-    return 4;
-}
-int CPU::OP_0x1C()
-{
-    byteINC(m_Registers.e);
-    return 4;
-}
-int CPU::OP_0x24()
-{
-    byteINC(m_Registers.h);
-    return 4;
-}
-int CPU::OP_0x2C()
-{
-    byteINC(m_Registers.l);
-    return 4;
-}
-int CPU::OP_0x34()
-{
-    byte_t hli{ m_Memory.readByte(m_Registers.get_hl()) };
-    byteINC(hli);
-    m_Memory.writeByte(m_Registers.get_hl(), hli);
-    return 12;
-}
-//DEC n
-int CPU::OP_0x3D()
-{
-    byteDEC(m_Registers.a);
-    return 4;
-}
-int CPU::OP_0x05()
-{
-    byteDEC(m_Registers.b);
-    return 4;
-}
-int CPU::OP_0x0D()
-{
-    byteDEC(m_Registers.c);
-    return 4;
-}
-int CPU::OP_0x15()
-{
-    byteDEC(m_Registers.d);
-    return 4;
-}
-int CPU::OP_0x1D()
-{
-    byteDEC(m_Registers.e);
-    return 4;
-}
-int CPU::OP_0x25()
-{
-    byteDEC(m_Registers.h);
-    return 4;
-}
-int CPU::OP_0x2D()
-{
-    byteDEC(m_Registers.l);
-    return 4;
-}
-int CPU::OP_0x35()
-{
-    byte_t hli{ m_Memory.readByte(m_Registers.get_hl()) };
-    byteDEC(hli);
-    m_Memory.writeByte(m_Registers.get_hl(), hli);
-    return 12;
-}
 //Word arithmatic
 //ADD HL,n
 int CPU::OP_0x09()

--- a/src/cpu_opcodes.cpp
+++ b/src/cpu_opcodes.cpp
@@ -8,6 +8,7 @@ void CPU::setupTables()
     for(byte_t i = 0; i < c_INSTRUCTION_TABLE_SIZE; ++i)
     {
         instructionTable[i] = &CPU::OP_NOT_IMPLEMTED;
+        instructionTable2[i] = &CPU::OP_NOT_IMPLEMTED2;
     }
 
     //LD nn,n
@@ -138,87 +139,17 @@ void CPU::setupTables()
     instructionTable[0xC1] = &CPU::OP_0xC1;
     instructionTable[0xD1] = &CPU::OP_0xD1;
     instructionTable[0xE1] = &CPU::OP_0xE1;
+    
     //Byte arithmetic with reg A
-    //ADD A,n
-    instructionTable[0x87] = &CPU::OP_0x87;
-    instructionTable[0x80] = &CPU::OP_0x80;
-    instructionTable[0x81] = &CPU::OP_0x81;
-    instructionTable[0x82] = &CPU::OP_0x82;
-    instructionTable[0x83] = &CPU::OP_0x83;
-    instructionTable[0x84] = &CPU::OP_0x84;
-    instructionTable[0x85] = &CPU::OP_0x85;
-    instructionTable[0x86] = &CPU::OP_0x86;
-    instructionTable[0xC6] = &CPU::OP_0xC6;
-    //ADC A,n
-    instructionTable[0x8F] = &CPU::OP_0x8F;
-    instructionTable[0x88] = &CPU::OP_0x88;
-    instructionTable[0x89] = &CPU::OP_0x89;
-    instructionTable[0x8A] = &CPU::OP_0x8A;
-    instructionTable[0x8B] = &CPU::OP_0x8B;
-    instructionTable[0x8C] = &CPU::OP_0x8C;
-    instructionTable[0x8D] = &CPU::OP_0x8D;
-    instructionTable[0x8E] = &CPU::OP_0x8E;
-    instructionTable[0xCE] = &CPU::OP_0xCE;
-    //SUB A, n
-    instructionTable[0x97] = &CPU::OP_0x97;
-    instructionTable[0x90] = &CPU::OP_0x90;
-    instructionTable[0x91] = &CPU::OP_0x91;
-    instructionTable[0x92] = &CPU::OP_0x92;
-    instructionTable[0x93] = &CPU::OP_0x93;
-    instructionTable[0x94] = &CPU::OP_0x94;
-    instructionTable[0x95] = &CPU::OP_0x95;
-    instructionTable[0x96] = &CPU::OP_0x96;
-    instructionTable[0xD6] = &CPU::OP_0xD6;
-    //SBC A,n
-    instructionTable[0x9F] = &CPU::OP_0x9F;
-    instructionTable[0x98] = &CPU::OP_0x98;
-    instructionTable[0x99] = &CPU::OP_0x99;
-    instructionTable[0x9A] = &CPU::OP_0x9A;
-    instructionTable[0x9B] = &CPU::OP_0x9B;
-    instructionTable[0x9C] = &CPU::OP_0x9C;
-    instructionTable[0x9D] = &CPU::OP_0x9D;
-    instructionTable[0x9E] = &CPU::OP_0x9E;
-    // int OP_0x??(); rip D8
-    //AND A, n
-    instructionTable[0xA7] = &CPU::OP_0xA7;
-    instructionTable[0xA0] = &CPU::OP_0xA0;
-    instructionTable[0xA1] = &CPU::OP_0xA1;
-    instructionTable[0xA2] = &CPU::OP_0xA2;
-    instructionTable[0xA3] = &CPU::OP_0xA3;
-    instructionTable[0xA4] = &CPU::OP_0xA4;
-    instructionTable[0xA5] = &CPU::OP_0xA5;
-    instructionTable[0xA6] = &CPU::OP_0xA6;
-    instructionTable[0xE6] = &CPU::OP_0xE6;
-    //OR A, n
-    instructionTable[0xB7] = &CPU::OP_0xB7;
-    instructionTable[0xB0] = &CPU::OP_0xB0;
-    instructionTable[0xB1] = &CPU::OP_0xB1;
-    instructionTable[0xB2] = &CPU::OP_0xB2;
-    instructionTable[0xB3] = &CPU::OP_0xB3;
-    instructionTable[0xB4] = &CPU::OP_0xB4;
-    instructionTable[0xB5] = &CPU::OP_0xB5;
-    instructionTable[0xB6] = &CPU::OP_0xB6;
-    instructionTable[0xF6] = &CPU::OP_0xF6;
-    //XOR A, n
-    instructionTable[0xAF] = &CPU::OP_0xAF;
-    instructionTable[0xA8] = &CPU::OP_0xA8;
-    instructionTable[0xA9] = &CPU::OP_0xA9;
-    instructionTable[0xAA] = &CPU::OP_0xAA;
-    instructionTable[0xAB] = &CPU::OP_0xAB;
-    instructionTable[0xAC] = &CPU::OP_0xAC;
-    instructionTable[0xAD] = &CPU::OP_0xAD;
-    instructionTable[0xAE] = &CPU::OP_0xAE;
-    instructionTable[0xEE] = &CPU::OP_0xEE;
-    //CP A, n
-    instructionTable[0xBF] = &CPU::OP_0xBF;
-    instructionTable[0xB8] = &CPU::OP_0xB8;
-    instructionTable[0xB9] = &CPU::OP_0xB9;
-    instructionTable[0xBA] = &CPU::OP_0xBA;
-    instructionTable[0xBB] = &CPU::OP_0xBB;
-    instructionTable[0xBC] = &CPU::OP_0xBC;
-    instructionTable[0xBD] = &CPU::OP_0xBD;
-    instructionTable[0xBE] = &CPU::OP_0xBE;
-    instructionTable[0xFE] = &CPU::OP_0xFE;
+    for (byte_t i{ 0x80 }; i < 0xC0; ++i)
+    {
+        instructionTable2[i] = &CPU::cpu_byteArithmetic;
+    }
+    for (byte_t i{ 0xC6 }; i >= 0xC6; i+=0x8)
+    {
+        instructionTable2[i] = &CPU::cpu_byteArithmetic;
+    }
+
     //INC n
     instructionTable[0x3C] = &CPU::OP_0x3C;
     instructionTable[0x04] = &CPU::OP_0x04;
@@ -378,30 +309,24 @@ void CPU::setupTables()
 
 int CPU::OP_NOT_IMPLEMTED()
 {
-    throw std::runtime_error("OPCODE NOT IMPLEMENTED!");
+    throw std::runtime_error("OPCODE NOT IMPLEMENTED in table 1!");
 }
 
-//Prefixed instructions
-byte_t& CPU::CBopcodeToRegister(byte_t opcode)
+int CPU::OP_NOT_IMPLEMTED2(const byte_t&)
 {
-    switch(opcode & 0xFu)
+    throw std::runtime_error("OPCODE NOT IMPLEMENTED in table 2!");
+}
+
+
+int CPU::opcode_Translator(byte_t opcode)
+{
+    if ( (opcode>=0x80 && opcode<=0xBF) || (opcode>=0x80 && (opcode%8)==6))
     {
-        case 0: case 8:
-        return m_Registers.b;
-        case 1: case 9:
-        return m_Registers.c; break;
-        case 2: case 10:
-        return m_Registers.d; break;
-        case 3: case 11:
-        return m_Registers.e; break;
-        case 4: case 12:
-        return m_Registers.h; break;
-        case 5: case 13:
-        return m_Registers.l; break;
-        case 7: case 15:
-        return m_Registers.a; break;
-        default: 
-            throw std::runtime_error("INVALID OPCODE used in CPU::CBopcodeToRegister");
+        return ((*this).*(instructionTable2[opcode]))(opcode);
+    }
+    else
+    {
+        return ((*this).*(instructionTable[opcode]))();
     }
 }
 
@@ -414,7 +339,7 @@ int CPU::CBopcode_Translator(byte_t opcode)
     {
         if (!usingHLI)
         {
-            byte_t& reg = CBopcodeToRegister(opcode);
+            byte_t& reg = getRegister(opcode%8);
             std::cout <<"\n";
             m_log(LOG_INFO) << "reg before is: " << +reg << ", f: "<< +m_Registers.f << ".\n";
             ((*this).*(preCB0x40_FunctionTable[opcode]))(reg);
@@ -435,7 +360,7 @@ int CPU::CBopcode_Translator(byte_t opcode)
         m_log(LOG_DEBUG) << "CB Opcode: " << +opcode << ", performing on bit: " << bit << "\n";  
         if (!usingHLI)
         {
-            byte_t& reg = CBopcodeToRegister(opcode);
+            byte_t& reg = getRegister(opcode%8);
             std::cout <<"\n";
             m_log(LOG_INFO) << "reg before is: " << +reg << ", f: "<< +m_Registers.f <<".\n";
             ((*this).*(postCB0x40_FunctionTable[opcode-0x40]))(reg, bit);
@@ -910,28 +835,28 @@ int CPU::OP_0xF0()
 //LD n,nn
 int CPU::OP_0x01()
 {
-    wordLoad(WordLoadTarget::BC, WordLoadSource::D16);
+    m_Registers.set_bc(readNextWord());
     return 12;
 }
 int CPU::OP_0x11()
 {
-    wordLoad(WordLoadTarget::DE, WordLoadSource::D16);
+    m_Registers.set_de(readNextWord());
     return 12;
 }
 int CPU::OP_0x21()
 {
-    wordLoad(WordLoadTarget::HL, WordLoadSource::D16);
+    m_Registers.set_hl(readNextWord());
     return 12;
 }
 int CPU::OP_0x31()
 {
-    wordLoad(WordLoadTarget::SP, WordLoadSource::D16);
+    m_SP = readNextWord();
     return 12;
 }
 //LD SP,HL
 int CPU::OP_0xF9()
 {
-    wordLoad(WordLoadTarget::SP, WordLoadSource::HL);
+    m_SP = m_Registers.get_hl();
     return 8;
 }
 //LD HL,SP+n
@@ -940,13 +865,33 @@ int CPU::OP_0xF8()
 {
     m_log(LOG_ERROR) << "opcode 0xF8 needs to be signed!" << "\n";
     std::exit(EXIT_FAILURE);
-    wordLoad(WordLoadTarget::HL, WordLoadSource::SPpD8);
+
+    // byte_t d8{ readNextByte() };
+    // m_Registers.f.zero = false;
+    // m_Registers.f.subtract = false;
+
+    // unsigned int v{ static_cast<unsigned int>(m_SP)+static_cast<unsigned int>(d8) };
+    // bool carry{ v > 0xFFFF };
+    // m_Registers.f.carry = carry;
+
+    // bool half_carry{ ((m_SP & 0xF) + (d8 & 0xF)) > 0xF };
+    // m_Registers.f.half_carry = half_carry;
+
+    // value = m_SP+d8; 
+
     return 12;
 }
 //LD (nn),SP
 int CPU::OP_0x08()
 {
-    wordLoad(WordLoadTarget::D16I, WordLoadSource::SP);
+    word_t address{ readNextWord() };
+
+    byte_t lsb{ static_cast<byte_t>(m_SP & 0xF) };
+    byte_t msb{ static_cast<byte_t>(m_SP >> 4) };
+    
+    m_Memory.writeByte(address, lsb);
+    m_Memory.writeByte(address+1, msb);
+
     return 20;
 }
 //PUSH nn
@@ -973,7 +918,17 @@ int CPU::OP_0xE5()
 //POP nn
 int CPU::OP_0xF1()
 {
-    m_Registers.set_af(pop());
+    m_log(LOG_ERROR) << "Opcode 0xF1 needs to affect flags somehow" << "\n";
+    std::exit(EXIT_FAILURE);
+
+    word_t data{ pop() };
+    
+    m_Registers.f.zero = !data;
+    // m_Registers.f.subtract
+    // m_Registers.f.half_carry
+    // m_Registers.f.carry
+
+    m_Registers.set_af(data);
     return 12;
 }
 int CPU::OP_0xC1()
@@ -991,369 +946,9 @@ int CPU::OP_0xE1()
     m_Registers.set_hl(pop());
     return 12;
 }
-//ADD A,n
-int CPU::OP_0x87()
-{
-    byteAdd(m_Registers.a,m_Registers.a);
-    return 4;
-}
-int CPU::OP_0x80()
-{
-    byteAdd(m_Registers.a,m_Registers.b);
-    return 4;
-}
-int CPU::OP_0x81()
-{
-    byteAdd(m_Registers.a,m_Registers.c);
-    return 4;
-}
-int CPU::OP_0x82()
-{
-    byteAdd(m_Registers.a,m_Registers.d);
-    return 4;
-}
-int CPU::OP_0x83()
-{
-    byteAdd(m_Registers.a,m_Registers.e);
-    return 4;
-}
-int CPU::OP_0x84()
-{
-    byteAdd(m_Registers.a,m_Registers.h);
-    return 4;
-}
-int CPU::OP_0x85()
-{
-    byteAdd(m_Registers.a,m_Registers.l);
-    return 4;
-}
-int CPU::OP_0x86()
-{
-    byteAdd(m_Registers.a, m_Memory.readByte(m_Registers.get_hl()));
-    return 8;
-}
-int CPU::OP_0xC6()
-{
-    byteAdd(m_Registers.a, readNextByte());
-    return 8;
-}
-//ADC A,n
-int CPU::OP_0x8F()
-{
-    byteAdd(m_Registers.a,m_Registers.a, true);
-    return 4;
-}
-int CPU::OP_0x88()
-{
-    byteAdd(m_Registers.a,m_Registers.b, true);
-    return 4;
-}
-int CPU::OP_0x89()
-{
-    byteAdd(m_Registers.a,m_Registers.c, true);
-    return 4;
-}
-int CPU::OP_0x8A()
-{
-    byteAdd(m_Registers.a,m_Registers.d, true);
-    return 4;
-}
-int CPU::OP_0x8B()
-{
-    byteAdd(m_Registers.a,m_Registers.e, true);
-    return 4;
-}
-int CPU::OP_0x8C()
-{
-    byteAdd(m_Registers.a,m_Registers.h, true);
-    return 4;
-}
-int CPU::OP_0x8D()
-{
-    byteAdd(m_Registers.a,m_Registers.l, true);
-    return 4;
-}
-int CPU::OP_0x8E()
-{
-    byteAdd(m_Registers.a, m_Memory.readByte(m_Registers.get_hl()), true);
-    return 8;
-}
-int CPU::OP_0xCE()
-{
-    byteAdd(m_Registers.a, readNextByte(), true);
-    return 8;
-}
-//SUB A, n
-int CPU::OP_0x97()
-{
-    byteSub(m_Registers.a,m_Registers.a);
-    return 4;
-}
-int CPU::OP_0x90()
-{
-    byteSub(m_Registers.a,m_Registers.b);
-    return 4;
-}
-int CPU::OP_0x91()
-{
-    byteSub(m_Registers.a,m_Registers.c);
-    return 4;
-}
-int CPU::OP_0x92()
-{
-    byteSub(m_Registers.a,m_Registers.d);
-    return 4;
-}
-int CPU::OP_0x93()
-{
-    byteSub(m_Registers.a,m_Registers.e);
-    return 4;
-}
-int CPU::OP_0x94()
-{
-    byteSub(m_Registers.a,m_Registers.h);
-    return 4;
-}
-int CPU::OP_0x95()
-{
-    byteSub(m_Registers.a,m_Registers.l);
-    return 4;
-}
-int CPU::OP_0x96()
-{
-    byteSub(m_Registers.a, m_Memory.readByte(m_Registers.get_hl()));
-    return 8;
-}
-int CPU::OP_0xD6()
-{
-    byteSub(m_Registers.a, readNextByte());
-    return 8;
-}
-//SBC A,n
-int CPU::OP_0x9F()
-{
-    byteSub(m_Registers.a,m_Registers.a, true);
-    return 4;
-}
-int CPU::OP_0x98()
-{
-    byteSub(m_Registers.a,m_Registers.b, true);
-    return 4;
-}
-int CPU::OP_0x99()
-{
-    byteSub(m_Registers.a,m_Registers.c, true);
-    return 4;
-}
-int CPU::OP_0x9A()
-{
-    byteSub(m_Registers.a,m_Registers.d, true);
-    return 4;
-}
-int CPU::OP_0x9B()
-{
-    byteSub(m_Registers.a,m_Registers.e, true);
-    return 4;
-}
-int CPU::OP_0x9C()
-{
-    byteSub(m_Registers.a,m_Registers.h, true);
-    return 4;
-}
-int CPU::OP_0x9D()
-{
-    byteSub(m_Registers.a,m_Registers.l, true);
-    return 4;
-}
-int CPU::OP_0x9E()
-{
-    byteSub(m_Registers.a, m_Memory.readByte(m_Registers.get_hl()), true);
-    return 8;
-}
-//AND A, n
-int CPU::OP_0xA7()
-{
-    byteAND(m_Registers.a,m_Registers.a);
-    return 4;
-}
-int CPU::OP_0xA0()
-{
-    byteAND(m_Registers.a,m_Registers.b);
-    return 4;
-}
-int CPU::OP_0xA1()
-{
-    byteAND(m_Registers.a,m_Registers.c);
-    return 4;
-}
-int CPU::OP_0xA2()
-{
-    byteAND(m_Registers.a,m_Registers.d);
-    return 4;
-}
-int CPU::OP_0xA3()
-{
-    byteAND(m_Registers.a,m_Registers.e);
-    return 4;
-}
-int CPU::OP_0xA4()
-{
-    byteAND(m_Registers.a,m_Registers.h);
-    return 4;
-}
-int CPU::OP_0xA5()
-{
-    byteAND(m_Registers.a,m_Registers.l);
-    return 4;
-}
-int CPU::OP_0xA6()
-{
-    byteAND(m_Registers.a,m_Memory.readByte(m_Registers.get_hl()));
-    return 8;
-}
-int CPU::OP_0xE6()
-{
-    byteAND(m_Registers.a,readNextByte());
-    return 8;
-}
-//OR A, n
-int CPU::OP_0xB7()
-{
-    byteOR(m_Registers.a,m_Registers.a);
-    return 4;
-}
-int CPU::OP_0xB0()
-{
-    byteOR(m_Registers.a,m_Registers.b);
-    return 4;
-}
-int CPU::OP_0xB1()
-{
-    byteOR(m_Registers.a,m_Registers.c);
-    return 4;
-}
-int CPU::OP_0xB2()
-{
-    byteOR(m_Registers.a,m_Registers.d);
-    return 4;
-}
-int CPU::OP_0xB3()
-{
-    byteOR(m_Registers.a,m_Registers.e);
-    return 4;
-}
-int CPU::OP_0xB4()
-{
-    byteOR(m_Registers.a,m_Registers.h);
-    return 4;
-}
-int CPU::OP_0xB5()
-{
-    byteOR(m_Registers.a,m_Registers.l);
-    return 4;
-}
-int CPU::OP_0xB6()
-{
-    byteOR(m_Registers.a,m_Memory.readByte(m_Registers.get_hl()));
-    return 8;
-}
-int CPU::OP_0xF6()
-{
-    byteOR(m_Registers.a,readNextByte());
-    return 8;
-}
-//XOR A, n
-int CPU::OP_0xAF()
-{
-    byteXOR(m_Registers.a,m_Registers.a);
-    return 4;
-}
-int CPU::OP_0xA8()
-{
-    byteXOR(m_Registers.a,m_Registers.b);
-    return 4;
-}
-int CPU::OP_0xA9()
-{
-    byteXOR(m_Registers.a,m_Registers.c);
-    return 4;
-}
-int CPU::OP_0xAA()
-{
-    byteXOR(m_Registers.a,m_Registers.d);
-    return 4;
-}
-int CPU::OP_0xAB()
-{
-    byteXOR(m_Registers.a,m_Registers.e);
-    return 4;
-}
-int CPU::OP_0xAC()
-{
-    byteXOR(m_Registers.a,m_Registers.h);
-    return 4;
-}
-int CPU::OP_0xAD()
-{
-    byteXOR(m_Registers.a,m_Registers.l);
-    return 4;
-}
-int CPU::OP_0xAE()
-{
-    byteXOR(m_Registers.a,m_Memory.readByte(m_Registers.get_hl()));
-    return 8;
-}
-int CPU::OP_0xEE()
-{
-    byteXOR(m_Registers.a,readNextByte());
-    return 8;
-}
-//CP A, n
-int CPU::OP_0xBF()
-{
-    byteCP(m_Registers.a, m_Registers.a);
-    return 4;
-}
-int CPU::OP_0xB8()
-{
-    byteCP(m_Registers.a, m_Registers.b);
-    return 4;
-}
-int CPU::OP_0xB9()
-{
-    byteCP(m_Registers.a, m_Registers.c);
-    return 4;
-}
-int CPU::OP_0xBA()
-{
-    byteCP(m_Registers.a, m_Registers.d);
-    return 4;
-}
-int CPU::OP_0xBB()
-{
-    byteCP(m_Registers.a, m_Registers.e);
-    return 4;
-}
-int CPU::OP_0xBC()
-{
-    byteCP(m_Registers.a, m_Registers.h);
-    return 4;
-}
-int CPU::OP_0xBD()
-{
-    byteCP(m_Registers.a, m_Registers.l);
-    return 4;
-}
-int CPU::OP_0xBE()
-{
-    byteCP(m_Registers.a, m_Memory.readByte(m_Registers.get_hl()));
-    return 8;
-}
-int CPU::OP_0xFE()
-{
-    byteCP(m_Registers.a,readNextByte());
-    return 8;
-}
+
+
+
 //INC n
 int CPU::OP_0x3C()
 {

--- a/src/cpu_opcodes.cpp
+++ b/src/cpu_opcodes.cpp
@@ -244,7 +244,7 @@ int CPU::CBopcode_Translator(byte_t opcode)
     }
 }
 
-//Non prefixed Instructions
+//Specific Commands
 //byte Loads
 //LD A,n
 int CPU::OP_0x0A()
@@ -365,12 +365,16 @@ int CPU::OP_0xF9()
 //LDHL SP,n
 int CPU::OP_0xF8()
 {
-    m_log(LOG_ERROR) << "opcode 0xF8 needs to be signed!" << "\n";
+    m_log(LOG_ERROR) << "opcode 0xF8 needs to have correct registers!" << "\n";
+
+    byte_t usignedValue{ readNextByte() };
+    word_t sum{ unsignedAddition(m_SP, usignedValue) };
+    m_Registers.set_hl(sum);
+
     std::exit(EXIT_FAILURE);
 
-    // byte_t d8{ readNextByte() };
-    // m_Registers.f.zero = false;
-    // m_Registers.f.subtract = false;
+    m_Registers.f.zero = false;
+    m_Registers.f.subtract = false;
 
     // unsigned int v{ static_cast<unsigned int>(m_SP)+static_cast<unsigned int>(d8) };
     // bool carry{ v > 0xFFFF };

--- a/src/cpu_opcodes.cpp
+++ b/src/cpu_opcodes.cpp
@@ -213,14 +213,10 @@ void CPU::setupTables()
     instructionTable[0xDC] = &CPU::OP_0xDC;
     //Restarts
     //RST n
-    instructionTable[0xC7] = &CPU::OP_0xC7;
-    instructionTable[0xCF] = &CPU::OP_0xCF;
-    instructionTable[0xD7] = &CPU::OP_0xD7;
-    instructionTable[0xDF] = &CPU::OP_0xDF;
-    instructionTable[0xE7] = &CPU::OP_0xE7;
-    instructionTable[0xEF] = &CPU::OP_0xEF;
-    instructionTable[0xF7] = &CPU::OP_0xF7;
-    instructionTable[0xFF] = &CPU::OP_0xFF;
+    for (byte_t i{ 0xC7 }; i >= 0xC7; i+=0x8)
+    {
+        instructionTable2[i] = &CPU::cpu_restart;
+    }
     //Returns
     //RET
     instructionTable[0xC9] = &CPU::OP_0xC9;
@@ -1208,48 +1204,6 @@ int CPU::OP_0xDC()
 {
     call(JumpTest::Carry, readNextWord());
     return 12;
-}
-//Restarts
-//RST n
-int CPU::OP_0xC7()
-{
-    restart(0x00);
-    return  32;
-}
-int CPU::OP_0xCF()
-{
-    restart(0x08);
-    return  32;
-}
-int CPU::OP_0xD7()
-{
-    restart(0x10);
-    return  32;
-}
-int CPU::OP_0xDF()
-{
-    restart(0x18);
-    return  32;
-}
-int CPU::OP_0xE7()
-{
-    restart(0x20);
-    return  32;
-}
-int CPU::OP_0xEF()
-{
-    restart(0x28);
-    return  32;
-}
-int CPU::OP_0xF7()
-{
-    restart(0x30);
-    return  32;
-}
-int CPU::OP_0xFF()
-{
-    restart(0x38);
-    return  32;
 }
 //RET
 int CPU::OP_0xC9()

--- a/src/cpu_opcodes.cpp
+++ b/src/cpu_opcodes.cpp
@@ -211,6 +211,8 @@ int CPU::opcode_Translator(byte_t opcode)
     }
     else
     {
+        m_log(LOG_INFO) << "PC: " << +(m_PC) << ", Opcode: 0x" 
+                        << +opcode  << " \n";
         return ((*this).*(instructionTable[opcode]))();
     }
 }
@@ -235,8 +237,6 @@ int CPU::CBopcode_Translator(byte_t opcode)
                     << bitFunction[funcIdx].second << " "
                     << ((opcode >= 0x40) ? std::to_string(bit) : "") << " "  
                     << getRegisterStr(regIdx) << "\n";
-    if (opcode != 0x7c)
-        getchar();
 
     if (regIdx != 6)
     {

--- a/src/cpu_opcodes.cpp
+++ b/src/cpu_opcodes.cpp
@@ -11,106 +11,35 @@ void CPU::setupTables()
         instructionTable2[i] = &CPU::OP_NOT_IMPLEMTED2;
     }
 
-    //LD nn,n
-    instructionTable[0x06] = &CPU::OP_0x06;
-    instructionTable[0x0E] = &CPU::OP_0x0E;
-    instructionTable[0x16] = &CPU::OP_0x16;
-    instructionTable[0x1E] = &CPU::OP_0x1E;
-    instructionTable[0x26] = &CPU::OP_0x26;
-    instructionTable[0x2E] = &CPU::OP_0x2E;
-    //LD r1, r2
-    instructionTable[0x7F] = &CPU::OP_0x7F;
-    instructionTable[0x78] = &CPU::OP_0x78;
-    instructionTable[0x79] = &CPU::OP_0x79;
-    instructionTable[0x7A] = &CPU::OP_0x7A;
-    instructionTable[0x7B] = &CPU::OP_0x7B;
-    instructionTable[0x7C] = &CPU::OP_0x7C;
-    instructionTable[0x7D] = &CPU::OP_0x7D;
-    instructionTable[0x7E] = &CPU::OP_0x7E;
-    instructionTable[0x40] = &CPU::OP_0x40;
-    instructionTable[0x41] = &CPU::OP_0x41;
-    instructionTable[0x42] = &CPU::OP_0x42;
-    instructionTable[0x43] = &CPU::OP_0x43;
-    instructionTable[0x44] = &CPU::OP_0x44;
-    instructionTable[0x45] = &CPU::OP_0x45;
-    instructionTable[0x46] = &CPU::OP_0x46;
-    instructionTable[0x48] = &CPU::OP_0x48;
-    instructionTable[0x49] = &CPU::OP_0x49;
-    instructionTable[0x4A] = &CPU::OP_0x4A;
-    instructionTable[0x4B] = &CPU::OP_0x4B;
-    instructionTable[0x4C] = &CPU::OP_0x4C;
-    instructionTable[0x4D] = &CPU::OP_0x4D;
-    instructionTable[0x4E] = &CPU::OP_0x4E;
-    instructionTable[0x50] = &CPU::OP_0x50;
-    instructionTable[0x51] = &CPU::OP_0x51;
-    instructionTable[0x52] = &CPU::OP_0x52;
-    instructionTable[0x53] = &CPU::OP_0x53;
-    instructionTable[0x54] = &CPU::OP_0x54;
-    instructionTable[0x55] = &CPU::OP_0x55;
-    instructionTable[0x56] = &CPU::OP_0x56;
-    instructionTable[0x58] = &CPU::OP_0x58;
-    instructionTable[0x59] = &CPU::OP_0x59;
-    instructionTable[0x5A] = &CPU::OP_0x5A;
-    instructionTable[0x5B] = &CPU::OP_0x5B;
-    instructionTable[0x5C] = &CPU::OP_0x5C;
-    instructionTable[0x5D] = &CPU::OP_0x5D;
-    instructionTable[0x5E] = &CPU::OP_0x5E;
-    instructionTable[0x60] = &CPU::OP_0x60;
-    instructionTable[0x61] = &CPU::OP_0x61;
-    instructionTable[0x62] = &CPU::OP_0x62;
-    instructionTable[0x63] = &CPU::OP_0x63;
-    instructionTable[0x64] = &CPU::OP_0x64;
-    instructionTable[0x65] = &CPU::OP_0x65;
-    instructionTable[0x66] = &CPU::OP_0x66;
-    instructionTable[0x68] = &CPU::OP_0x68;
-    instructionTable[0x69] = &CPU::OP_0x69;
-    instructionTable[0x6A] = &CPU::OP_0x6A;
-    instructionTable[0x6B] = &CPU::OP_0x6B;
-    instructionTable[0x6C] = &CPU::OP_0x6C;
-    instructionTable[0x6D] = &CPU::OP_0x6D;
-    instructionTable[0x6E] = &CPU::OP_0x6E;
-    instructionTable[0x70] = &CPU::OP_0x70;
-    instructionTable[0x71] = &CPU::OP_0x71;
-    instructionTable[0x72] = &CPU::OP_0x72;
-    instructionTable[0x73] = &CPU::OP_0x73;
-    instructionTable[0x74] = &CPU::OP_0x74;
-    instructionTable[0x75] = &CPU::OP_0x75;
-    instructionTable[0x36] = &CPU::OP_0x36;
+
+    for (byte_t i{ 0x40 }; i < 0x80; ++i)
+    {
+        instructionTable2[i] = &CPU::cpu_byteLoad;
+    }
+    for (byte_t i{ 0x06 }; i <= 0x3E; i+=0x8)
+    {
+        instructionTable2[i] = &CPU::cpu_byteLoad;
+    }
+    
     //LD A,n
     instructionTable[0x0A] = &CPU::OP_0x0A;
     instructionTable[0x1A] = &CPU::OP_0x1A;
     instructionTable[0xFA] = &CPU::OP_0xFA;
-    instructionTable[0x3E] = &CPU::OP_0x3E;
     //LD n,A
-    instructionTable[0x47] = &CPU::OP_0x47;
-    instructionTable[0x4F] = &CPU::OP_0x4F;
-    instructionTable[0x57] = &CPU::OP_0x57;
-    instructionTable[0x5F] = &CPU::OP_0x5F;
-    instructionTable[0x67] = &CPU::OP_0x67;
-    instructionTable[0x6F] = &CPU::OP_0x6F;
     instructionTable[0x02] = &CPU::OP_0x02;
     instructionTable[0x12] = &CPU::OP_0x12;
-    instructionTable[0x77] = &CPU::OP_0x77;
     instructionTable[0xEA] = &CPU::OP_0xEA;
     //LD A,(C)
     instructionTable[0xF2] = &CPU::OP_0xF2;
     //LD (C),A
     instructionTable[0xE2] = &CPU::OP_0xE2;
-    //LD A,(HLD)
     //LD A,(HL-)
-    //LDD A,(HL)
     instructionTable[0x3A] = &CPU::OP_0x3A;
-    //LD (HLD),A
     //LD (HL-),A
-    //LDD (HL),A
     instructionTable[0x32] = &CPU::OP_0x32;
-    //LD A,(HLI)
     //LD A,(HL+)
-    //LDI A,(HL)
     instructionTable[0x2A] = &CPU::OP_0x2A;
-    //LD (HLI),A
     //LD (HL+),A
-    //LDI (HL),A
     instructionTable[0x22] = &CPU::OP_0x22;
     //LDH (n),A
     instructionTable[0xE0] = &CPU::OP_0xE0;
@@ -316,7 +245,13 @@ int CPU::OP_NOT_IMPLEMTED2(const byte_t&)
 
 int CPU::opcode_Translator(byte_t opcode)
 {
-    if ( (opcode>=0x80 && opcode<=0xBF) || (opcode>=0x80 && (opcode%8)==6))
+    if (
+        (opcode>=0x80 && opcode<0xC0) || //arithmetic
+        (opcode>=0x80 && (opcode%8)==6) || //arithmetic
+        (opcode>=0x40 && opcode<0x80 && opcode!=0x76) || //byteLoad
+        (opcode<0x40 && (opcode%8)==6) || //byteLoad
+        (opcode>=0xC0 && (opcode%8)==7) //rst
+    ) 
     {
         return ((*this).*(instructionTable2[opcode]))(opcode);
     }
@@ -375,453 +310,88 @@ int CPU::CBopcode_Translator(byte_t opcode)
 
 //Non prefixed Instructions
 //byte Loads
-//LD nn,n
-int CPU::OP_0x06()
-{
-    byteLoad(ByteLoadTarget::B, ByteLoadSource::D8);
-    return 8;
-}
-int CPU::OP_0x0E()
-{
-    byteLoad(ByteLoadTarget::C, ByteLoadSource::D8);
-    return 8;
-}
-int CPU::OP_0x16()
-{
-    byteLoad(ByteLoadTarget::D, ByteLoadSource::D8);
-    return 8;
-}
-int CPU::OP_0x1E()
-{
-    byteLoad(ByteLoadTarget::E, ByteLoadSource::D8);
-    return 8;
-}
-int CPU::OP_0x26()
-{
-    byteLoad(ByteLoadTarget::H, ByteLoadSource::D8);
-    return 8;
-}
-int CPU::OP_0x2E()
-{
-    byteLoad(ByteLoadTarget::L, ByteLoadSource::D8);
-    return 8;
-}
-//LD r1, r2
-int CPU::OP_0x7F()
-{
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::A);
-    return 4;
-}
-int CPU::OP_0x78()
-{
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::B);
-    return 4;
-}
-int CPU::OP_0x79()
-{
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::C);
-    return 4;
-}
-int CPU::OP_0x7A()
-{
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::D);
-    return 4;
-}
-int CPU::OP_0x7B()
-{
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::E);
-    return 4;
-}
-int CPU::OP_0x7C()
-{
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::H);
-    return 4;
-}
-int CPU::OP_0x7D()
-{
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::L);
-    return 4;
-}
-int CPU::OP_0x7E()
-{
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::HLI);
-    return 8;
-}
-int CPU::OP_0x40()
-{
-    byteLoad(ByteLoadTarget::B, ByteLoadSource::B);
-    return 4;
-}
-int CPU::OP_0x41()
-{
-    byteLoad(ByteLoadTarget::B, ByteLoadSource::C);
-    return 4;
-}
-int CPU::OP_0x42()
-{
-    byteLoad(ByteLoadTarget::B, ByteLoadSource::D);
-    return 4;
-}
-int CPU::OP_0x43()
-{
-    byteLoad(ByteLoadTarget::B, ByteLoadSource::E);
-    return 4;
-}
-int CPU::OP_0x44()
-{
-    byteLoad(ByteLoadTarget::B, ByteLoadSource::H);
-    return 4;
-}
-int CPU::OP_0x45()
-{
-    byteLoad(ByteLoadTarget::B, ByteLoadSource::L);
-    return 4;
-}
-int CPU::OP_0x46()
-{
-    byteLoad(ByteLoadTarget::B, ByteLoadSource::HLI);
-    return 8;
-}
-int CPU::OP_0x48()
-{
-    byteLoad(ByteLoadTarget::C, ByteLoadSource::B);
-    return 4;
-}
-int CPU::OP_0x49()
-{
-    byteLoad(ByteLoadTarget::C, ByteLoadSource::C);
-    return 4;
-}
-int CPU::OP_0x4A()
-{
-    byteLoad(ByteLoadTarget::C, ByteLoadSource::D);
-    return 4;
-}
-int CPU::OP_0x4B()
-{
-    byteLoad(ByteLoadTarget::C, ByteLoadSource::E);
-    return 4;
-}
-int CPU::OP_0x4C()
-{
-    byteLoad(ByteLoadTarget::C, ByteLoadSource::H);
-    return 4;
-}
-int CPU::OP_0x4D()
-{
-    byteLoad(ByteLoadTarget::C, ByteLoadSource::L);
-    return 4;
-}
-int CPU::OP_0x4E()
-{
-    byteLoad(ByteLoadTarget::C, ByteLoadSource::HLI);
-    return 8;
-}
-int CPU::OP_0x50()
-{
-    byteLoad(ByteLoadTarget::D, ByteLoadSource::B);
-    return 4;
-}
-int CPU::OP_0x51()
-{
-    byteLoad(ByteLoadTarget::D, ByteLoadSource::C);
-    return 4;
-}
-int CPU::OP_0x52()
-{
-    byteLoad(ByteLoadTarget::D, ByteLoadSource::D);
-    return 4;
-}
-int CPU::OP_0x53()
-{
-    byteLoad(ByteLoadTarget::D, ByteLoadSource::E);
-    return 4;
-}
-int CPU::OP_0x54()
-{
-    byteLoad(ByteLoadTarget::D, ByteLoadSource::H);
-    return 4;
-}
-int CPU::OP_0x55()
-{
-    byteLoad(ByteLoadTarget::D, ByteLoadSource::L);
-    return 4;
-}
-int CPU::OP_0x56()
-{
-    byteLoad(ByteLoadTarget::D, ByteLoadSource::HLI);
-    return 8;
-}
-int CPU::OP_0x58()
-{
-    byteLoad(ByteLoadTarget::E, ByteLoadSource::B);
-    return 4;
-}
-int CPU::OP_0x59()
-{
-    byteLoad(ByteLoadTarget::E, ByteLoadSource::C);
-    return 4;
-}
-int CPU::OP_0x5A()
-{
-    byteLoad(ByteLoadTarget::E, ByteLoadSource::D);
-    return 4;
-}
-int CPU::OP_0x5B()
-{
-    byteLoad(ByteLoadTarget::E, ByteLoadSource::E);
-    return 4;
-}
-int CPU::OP_0x5C()
-{
-    byteLoad(ByteLoadTarget::E, ByteLoadSource::H);
-    return 4;
-}
-int CPU::OP_0x5D()
-{
-    byteLoad(ByteLoadTarget::E, ByteLoadSource::L);
-    return 4;
-}
-int CPU::OP_0x5E()
-{
-    byteLoad(ByteLoadTarget::E, ByteLoadSource::HLI);
-    return 8;
-}
-int CPU::OP_0x60()
-{
-    byteLoad(ByteLoadTarget::H, ByteLoadSource::B);
-    return 4;
-}
-int CPU::OP_0x61()
-{
-    byteLoad(ByteLoadTarget::H, ByteLoadSource::C);
-    return 4;
-}
-int CPU::OP_0x62()
-{
-    byteLoad(ByteLoadTarget::H, ByteLoadSource::D);
-    return 4;
-}
-int CPU::OP_0x63()
-{
-    byteLoad(ByteLoadTarget::H, ByteLoadSource::E);
-    return 4;
-}
-int CPU::OP_0x64()
-{
-    byteLoad(ByteLoadTarget::H, ByteLoadSource::H);
-    return 4;
-}
-int CPU::OP_0x65()
-{
-    byteLoad(ByteLoadTarget::H, ByteLoadSource::L);
-    return 4;
-}
-int CPU::OP_0x66()
-{
-    byteLoad(ByteLoadTarget::H, ByteLoadSource::HLI);
-    return 8;
-}
-int CPU::OP_0x68()
-{
-    byteLoad(ByteLoadTarget::L, ByteLoadSource::B);
-    return 4;
-}
-int CPU::OP_0x69()
-{
-    byteLoad(ByteLoadTarget::L, ByteLoadSource::C);
-    return 4;
-}
-int CPU::OP_0x6A()
-{
-    byteLoad(ByteLoadTarget::L, ByteLoadSource::D);
-    return 4;
-}
-int CPU::OP_0x6B()
-{
-    byteLoad(ByteLoadTarget::L, ByteLoadSource::E);
-    return 4;
-}
-int CPU::OP_0x6C()
-{
-    byteLoad(ByteLoadTarget::L, ByteLoadSource::H);
-    return 4;
-}
-int CPU::OP_0x6D()
-{
-    byteLoad(ByteLoadTarget::L, ByteLoadSource::L);
-    return 4;
-}
-int CPU::OP_0x6E()
-{
-    byteLoad(ByteLoadTarget::L, ByteLoadSource::HLI);
-    return 8;
-}
-int CPU::OP_0x70()
-{
-    byteLoad(ByteLoadTarget::HLI, ByteLoadSource::B);
-    return 8;
-}
-int CPU::OP_0x71()
-{
-    byteLoad(ByteLoadTarget::HLI, ByteLoadSource::C);
-    return 8;
-}
-int CPU::OP_0x72()
-{
-    byteLoad(ByteLoadTarget::HLI, ByteLoadSource::D);
-    return 8;
-}
-int CPU::OP_0x73()
-{
-    byteLoad(ByteLoadTarget::HLI, ByteLoadSource::E);
-    return 8;
-}
-int CPU::OP_0x74()
-{
-    byteLoad(ByteLoadTarget::HLI, ByteLoadSource::H);
-    return 8;
-}
-int CPU::OP_0x75()
-{
-    byteLoad(ByteLoadTarget::HLI, ByteLoadSource::L);
-    return 8;
-}
-int CPU::OP_0x36()
-{
-    byteLoad(ByteLoadTarget::HLI, ByteLoadSource::D8);
-    return 12;
-}
 //LD A,n
 int CPU::OP_0x0A()
 {
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::BCI);
+    m_Registers.a = m_Memory.readByte(m_Registers.get_bc());
     return 8;
 }
 int CPU::OP_0x1A()
 {
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::DEI);
+    m_Registers.a = m_Memory.readByte(m_Registers.get_de());
     return 8;
 }
 int CPU::OP_0xFA()
 {
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::D16I);
+    m_Registers.a = m_Memory.readByte(readNextWord());
     return 16;
 }
-int CPU::OP_0x3E()
-{
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::D8);
-    return 8;
-}
 //LD n,A
-int CPU::OP_0x47()
-{
-    byteLoad(ByteLoadTarget::B, ByteLoadSource::A);
-    return  4;
-}
-int CPU::OP_0x4F()
-{
-    byteLoad(ByteLoadTarget::C, ByteLoadSource::A);
-    return  4;
-}
-int CPU::OP_0x57()
-{
-    byteLoad(ByteLoadTarget::D, ByteLoadSource::A);
-    return  4;
-}
-int CPU::OP_0x5F()
-{
-    byteLoad(ByteLoadTarget::E, ByteLoadSource::A);
-    return  4;
-}
-int CPU::OP_0x67()
-{
-    byteLoad(ByteLoadTarget::H, ByteLoadSource::A);
-    return  4;
-}
-int CPU::OP_0x6F()
-{
-    byteLoad(ByteLoadTarget::L, ByteLoadSource::A);
-    return  4;
-}
 int CPU::OP_0x02()
 {
-    byteLoad(ByteLoadTarget::BCI, ByteLoadSource::A);
+    m_Memory.writeByte(m_Registers.get_bc(), m_Registers.a);
     return  8;
 }
 int CPU::OP_0x12()
 {
-    byteLoad(ByteLoadTarget::DEI, ByteLoadSource::A);
-    return  8;
-}
-int CPU::OP_0x77()
-{
-    byteLoad(ByteLoadTarget::HLI, ByteLoadSource::A);
+    m_Memory.writeByte(m_Registers.get_de(), m_Registers.a);
     return  8;
 }
 int CPU::OP_0xEA()
 {
-    byteLoad(ByteLoadTarget::D16I, ByteLoadSource::A);
+    m_Memory.writeByte(readNextWord(), m_Registers.a);
     return  16;
 }
 //LD A,(C)
 int CPU::OP_0xF2()
 {
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::FF00pC);
+    m_Registers.a = m_Memory.readByte(0xFF00u + m_Registers.c);
     return 8;
 }
 //LD (C),A
 int CPU::OP_0xE2()
 {
-    byteLoad(ByteLoadTarget::FF00pC, ByteLoadSource::A);
+    m_Memory.writeByte(0xFF00u + m_Registers.c, m_Registers.a);
     return 8;
 }
-//LD A,(HLD)
 //LD A,(HL-)
-//LDD A,(HL)
 int CPU::OP_0x3A()
 {
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::HLI);
+    m_Registers.a = m_Memory.readByte(m_Registers.get_hl());
     m_Registers.set_hl( m_Registers.get_hl()-1u );
     return 8;
 }
-//LD (HLD),A
 //LD (HL-),A
-//LDD (HL),A
 int CPU::OP_0x32()
 {
-    byteLoad(ByteLoadTarget::HLI, ByteLoadSource::A);
+    m_Memory.writeByte(m_Registers.get_hl(), m_Registers.a);
     m_Registers.set_hl( m_Registers.get_hl()-1u );
     return 8;
 }
-//LD A,(HLI)
 //LD A,(HL+)
-//LDI A,(HL)
 int CPU::OP_0x2A()
 {
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::HLI);
+    m_Registers.a = m_Memory.readByte(m_Registers.get_hl());
     m_Registers.set_hl( m_Registers.get_hl()+1u );
     return 8;
 }
-//LD (HLI),A
 //LD (HL+),A
-//LDI (HL),A
 int CPU::OP_0x22()
 {
-    byteLoad(ByteLoadTarget::HLI, ByteLoadSource::A);
+    m_Memory.writeByte(m_Registers.get_hl(), m_Registers.a);
     m_Registers.set_hl( m_Registers.get_hl()+1u );
     return 8;
 }
 //LDH (n),A
 int CPU::OP_0xE0()
 {
-    byteLoad(ByteLoadTarget::FF00pD8, ByteLoadSource::A);
+    m_Memory.writeByte(0xFF00u + readNextByte(), m_Registers.a);
     return 12;
 }
 //LDH A,(n)
 int CPU::OP_0xF0()
 {
-    byteLoad(ByteLoadTarget::A, ByteLoadSource::FF00pD8);
+    m_Registers.a = m_Memory.readByte(0xFF00u + readNextByte());
     return 12;
 }
 

--- a/src/cpu_opcodes.cpp
+++ b/src/cpu_opcodes.cpp
@@ -642,17 +642,17 @@ int CPU::OP_0xE8()
 //INC nn
 int CPU::OP_0x03()
 {
-    m_Registers.set_bc(m_Registers.get_bc() + 1);
+    m_Registers.set_bc(m_Registers.get_bc() + 1u);
     return 8;
 }
 int CPU::OP_0x13()
 {
-    m_Registers.set_de(m_Registers.get_de() + 1);
+    m_Registers.set_de(m_Registers.get_de() + 1u);
     return 8;
 }
 int CPU::OP_0x23()
 {
-    m_Registers.set_hl(m_Registers.get_hl() + 1);
+    m_Registers.set_hl(m_Registers.get_hl() + 1u);
     return 8;
 }
 int CPU::OP_0x33()
@@ -663,17 +663,17 @@ int CPU::OP_0x33()
 //DEC nn
 int CPU::OP_0x0B()
 {
-    m_Registers.set_bc(m_Registers.get_bc() - 1);
+    m_Registers.set_bc(m_Registers.get_bc() - 1u);
     return 8;
 }
 int CPU::OP_0x1B()
 {
-    m_Registers.set_de(m_Registers.get_de() - 1);
+    m_Registers.set_de(m_Registers.get_de() - 1u);
     return 8;
 }
 int CPU::OP_0x2B()
 {
-    m_Registers.set_hl(m_Registers.get_hl() - 1);
+    m_Registers.set_hl(m_Registers.get_hl() - 1u);
     return 8;
 }
 int CPU::OP_0x3B()
@@ -850,9 +850,8 @@ int CPU::OP_0x00()
 //HALT
 int CPU::OP_0x76()
 {
-    m_log(LOG_ERROR) << "Halt not implemented" << "\n";
-    std::exit(EXIT_FAILURE);
     m_log(LOG_INFO) << "Executed Halt!" << "\n";
+    halted = true;
     return 4;
 }
 //STOP

--- a/src/cpu_operations.cpp
+++ b/src/cpu_operations.cpp
@@ -38,8 +38,8 @@ void CPU::push(word_t value)
 {
     byte_t lsb{ static_cast<byte_t>(value & 0xFFu) };
     byte_t msb{ static_cast<byte_t>(value >> 8) };
-    m_log(LOG_DEBUG) << "SP: " << +m_SP << ", will push " << +msb 
-                     << ", " << +lsb << " to stack!" << "\n"; 
+    // m_log(LOG_DEBUG) << "SP: " << +m_SP << ", will push " << +msb 
+    //                  << ", " << +lsb << " to stack!" << "\n"; 
 
     --m_SP;
     m_Memory.writeByte(m_SP, msb);
@@ -60,7 +60,7 @@ word_t CPU::pop()
     ++m_SP;
     word_t out{ static_cast<word_t>((msb << 8) | lsb) };
 
-    m_log(LOG_DEBUG) << "SP: " << +(m_SP-2) << ", Popped " << +out << " from stack!" << "\n"; 
+    // m_log(LOG_DEBUG) << "SP: " << +(m_SP-2) << ", Popped " << +out << " from stack!" << "\n"; 
     return out;
 }
 

--- a/src/cpu_operations.cpp
+++ b/src/cpu_operations.cpp
@@ -346,13 +346,48 @@ void CPU::byteCP(const byte_t& data)
     m_Registers.f.subtract = true;
 }
 
-/**
- * @brief Increments a passed byte, 
- * sets zero flag if zero, resets subtract flag,
- *  and sets half carry flag if carry from bit 3 occurs.
- * 
- * @param reg the byte to be incremented
- */
+int CPU::cpu_byteInc(const byte_t& opcode)
+{
+    int regIndex{ opcode/8 };
+
+    m_log(LOG_INFO) << "PC: " << +m_PC << ", Opcode: 0x" << +opcode << ", INC " 
+                    << getRegisterStr(regIndex) << "\n"; 
+
+    if (regIndex==6)
+    {
+        byte_t HLI{ m_Memory.readByte(m_Registers.get_hl()) };
+        byteINC(HLI);
+        m_Memory.writeByte(m_Registers.get_hl(), HLI);
+        return 12;
+    }
+    else
+    {
+        byteINC(getRegister(regIndex));
+        return 4;
+    }
+}
+
+int CPU::cpu_byteDec(const byte_t& opcode)
+{
+    int regIndex{ opcode/8 };
+
+    m_log(LOG_INFO) << "PC: " << +m_PC << ", Opcode: 0x" << +opcode << ", DEC " 
+                    << getRegisterStr(regIndex) << "\n"; 
+
+    if (regIndex==6)
+    {
+        byte_t HLI{ m_Memory.readByte(m_Registers.get_hl()) };
+        byteDEC(HLI);
+        m_Memory.writeByte(m_Registers.get_hl(), HLI);
+        return 12;
+    }
+    else
+    {
+        byteDEC(getRegister(regIndex));
+        return 4;
+    }
+}
+
 void CPU::byteINC(byte_t& reg)
 {
     byte_t unchanged{ reg };
@@ -362,13 +397,7 @@ void CPU::byteINC(byte_t& reg)
     m_Registers.f.subtract = false;
     m_Registers.f.half_carry = unchanged==0xFu;
 }
-/**
- * @brief Decrements a passed byte, 
- * sets zero flag if zero, sets subtract flag,
- *  and sets half carry flag if borrow from bit 3 occurs.
- * 
- * @param reg the byte to be decremented
- */
+
 void CPU::byteDEC(byte_t& reg)
 {
     signed int htest{ reg & 0xF };

--- a/src/cpu_operations.cpp
+++ b/src/cpu_operations.cpp
@@ -261,6 +261,20 @@ byte_t& CPU::getRegister(int index)
     return standardDataReg[index].get(); 
 }
 
+int CPU::cpu_restart(const byte_t& opcode)
+{
+    static const std::vector<byte_t> offsetVector
+    {
+        0x0u, 0x8u, 0x10u, 0x18u, 0x20u, 0x28u, 0x30u, 0x38u
+    };
+    int index{ (opcode /8) % 8 };
+
+    push(m_PC);
+    m_PC = (0x0000 + offsetVector[index]);
+
+    return 16;
+}
+
 int CPU::cpu_byteArithmetic(const byte_t& opcode)
 {
     using arithmeticFunctionPtr = void(CPU::*)(const byte_t&);

--- a/src/cpu_operations.cpp
+++ b/src/cpu_operations.cpp
@@ -29,11 +29,6 @@ byte_t CPU::readNextByte()
     return out;
 }
 
-void CPU::halt()
-{
-    halted = true;
-}
-
 /**
  * @brief Adds the given value to the stack, a byte at a time, msb first, 
  * also decrements the sp twice.

--- a/src/inc/cpu.h
+++ b/src/inc/cpu.h
@@ -25,7 +25,7 @@ private:
     using opcodeFnPtr2 = int(CPU::*)(const byte_t&);
     opcodeFnPtr instructionTable[c_INSTRUCTION_TABLE_SIZE]{};
     opcodeFnPtr2 instructionTable2[c_INSTRUCTION_TABLE_SIZE]{};
-    
+
 public:
     CPU();
     void frameUpdate();
@@ -58,6 +58,9 @@ private:
     int cpu_restart(const byte_t& opcode);
     int cpu_byteLoad(const byte_t& opcode);
 
+    int cpu_jumpRelative(const byte_t& opcode);
+    word_t unsignedAddition(const word_t& target, const byte_t& unsignedData);
+
     int cpu_byteArithmetic(const byte_t& opcode);
     void byteAdd(const byte_t& data);
     void byteAddWithCarry(const byte_t& data);
@@ -68,20 +71,21 @@ private:
     void byteXOR(const byte_t& data);
     void byteCP(const byte_t& data); //compare
 
+    void checkDAA(byte_t& byte);
+    void byteINC(byte_t& target); //increment
+    void byteDEC(byte_t& target); //decrement
+    
     //Jumps
     enum class JumpTest 
     {
         NotZero, Zero, NotCarry,
-        Carry, Always,
+        Carry, Always,  
     };
     bool testJumpTest(JumpTest type);
     void jump(JumpTest type, const word_t& address);
-    void jumpRelative(JumpTest type, const byte_t& unsignedData);
     void call(JumpTest type, const word_t& address);
     void return_(JumpTest type);
-    void checkDAA(byte_t& byte);
-    void byteINC(byte_t& target); //increment
-    void byteDEC(byte_t& target); //decrement
+    
     
     //Word Arithmetic
     void wordAdd(word_t& reg, const word_t& addValue);
@@ -204,13 +208,6 @@ private:
     int OP_0xDA();
     //JP (HL)
     int OP_0xE9();
-    // JR n
-    int OP_0x18();
-    //JR cc,n
-    int OP_0x20();
-    int OP_0x28();
-    int OP_0x30();
-    int OP_0x38();
     //Calls
     //Call nn
     int OP_0xCD();

--- a/src/inc/cpu.h
+++ b/src/inc/cpu.h
@@ -53,8 +53,8 @@ private:
     void interupts();
     void requestInterupt(int interupt);
     void performInterupt(int interupt);
-    void halt();
     
+//******************************************************************************************//
     void push(word_t value);
     word_t pop();
 

--- a/src/inc/cpu.h
+++ b/src/inc/cpu.h
@@ -62,7 +62,7 @@ private:
 
     byte_t& getRegister(int index);
     int opcode_Translator(byte_t opcode);
-
+    int cpu_restart(const byte_t& opcode);
     int cpu_byteArithmetic(const byte_t& opcode);
     void byteAdd(const byte_t& data);
     void byteAddWithCarry(const byte_t& data);
@@ -321,16 +321,6 @@ private:
     int OP_0xCC();
     int OP_0xD4();
     int OP_0xDC();
-    //Restarts
-    //RST n
-    int OP_0xC7();
-    int OP_0xCF();
-    int OP_0xD7();
-    int OP_0xDF();
-    int OP_0xE7();
-    int OP_0xEF();
-    int OP_0xF7();
-    int OP_0xFF();
     //Returns
     //RET
     int OP_0xC9();

--- a/src/inc/cpu.h
+++ b/src/inc/cpu.h
@@ -54,15 +54,15 @@ private:
     void requestInterupt(int interupt);
     void performInterupt(int interupt);
     void halt();
-
+    
     void push(word_t value);
     word_t pop();
-    void checkDAA(byte_t& byte);
-    
 
     byte_t& getRegister(int index);
     int opcode_Translator(byte_t opcode);
     int cpu_restart(const byte_t& opcode);
+    int cpu_byteLoad(const byte_t& opcode);
+
     int cpu_byteArithmetic(const byte_t& opcode);
     void byteAdd(const byte_t& data);
     void byteAddWithCarry(const byte_t& data);
@@ -73,6 +73,27 @@ private:
     void byteXOR(const byte_t& data);
     void byteCP(const byte_t& data); //compare
 
+    //Jumps
+    enum class JumpTest 
+    {
+        NotZero,
+        Zero,
+        NotCarry,
+        Carry,
+        Always
+    };
+    bool testJumpTest(JumpTest type);
+    void jump(JumpTest type, const word_t& address);
+    void jumpRelative(JumpTest type, const byte_t& unsignedData);
+    void call(JumpTest type, const word_t& address);
+    void return_(JumpTest type);
+    void restart(byte_t address);
+    void checkDAA(byte_t& byte);
+    void byteINC(byte_t& target); //increment
+    void byteDEC(byte_t& target); //decrement
+    
+    //Word Arithmetic
+    void wordAdd(word_t& reg, const word_t& addValue);
 
     //CB commands
     int CBopcode_Translator(byte_t opcode);
@@ -91,143 +112,29 @@ private:
     void rightShiftArithmetic(byte_t& byte);
     
 
-    //Jumps
-    enum class JumpTest 
-    {
-        NotZero,
-        Zero,
-        NotCarry,
-        Carry,
-        Always
-    };
-    bool testJumpTest(JumpTest type);
-    void jump(JumpTest type, const word_t& address);
-    void jumpRelative(JumpTest type, const byte_t& unsignedData);
-    void call(JumpTest type, const word_t& address);
-    void return_(JumpTest type);
-    void restart(byte_t address);
-
-    //Loads
-    enum class ByteLoadTarget
-    {
-        A, B, C, D, E, H, L, D16I, BCI, DEI, HLI, FF00pC, FF00pD8,
-    };
-    enum class ByteLoadSource
-    {
-        A, B, C, D, E, H, L, D8, D16I, BCI, DEI, HLI, FF00pC, FF00pD8,
-    };
-    void byteLoad(ByteLoadTarget ldTarget, ByteLoadSource ldSource);
-    
-
-    void byteINC(byte_t& target); //increment
-    void byteDEC(byte_t& target); //decrement
-    //Word Arithmetic
-    void wordAdd(word_t& reg, const word_t& addValue);
-
-    //Opcodes
     int OP_NOT_IMPLEMTED();
     int OP_NOT_IMPLEMTED2(const byte_t&);
+    //Unique Opcodes
     //byte Loads
-    //LD nn,n
-    int OP_0x06();
-    int OP_0x0E();
-    int OP_0x16();
-    int OP_0x1E();
-    int OP_0x26();
-    int OP_0x2E();
-    //LD r1, r2
-    int OP_0x7F();
-    int OP_0x78();
-    int OP_0x79();
-    int OP_0x7A();
-    int OP_0x7B();
-    int OP_0x7C();
-    int OP_0x7D();
-    int OP_0x7E();
-    int OP_0x40();
-    int OP_0x41();
-    int OP_0x42();
-    int OP_0x43();
-    int OP_0x44();
-    int OP_0x45();
-    int OP_0x46();
-    int OP_0x48();
-    int OP_0x49();
-    int OP_0x4A();
-    int OP_0x4B();
-    int OP_0x4C();
-    int OP_0x4D();
-    int OP_0x4E();
-    int OP_0x50();
-    int OP_0x51();
-    int OP_0x52();
-    int OP_0x53();
-    int OP_0x54();
-    int OP_0x55();
-    int OP_0x56();
-    int OP_0x58();
-    int OP_0x59();
-    int OP_0x5A();
-    int OP_0x5B();
-    int OP_0x5C();
-    int OP_0x5D();
-    int OP_0x5E();
-    int OP_0x60();
-    int OP_0x61();
-    int OP_0x62();
-    int OP_0x63();
-    int OP_0x64();
-    int OP_0x65();
-    int OP_0x66();
-    int OP_0x68();
-    int OP_0x69();
-    int OP_0x6A();
-    int OP_0x6B();
-    int OP_0x6C();
-    int OP_0x6D();
-    int OP_0x6E();
-    int OP_0x70();
-    int OP_0x71();
-    int OP_0x72();
-    int OP_0x73();
-    int OP_0x74();
-    int OP_0x75();
-    int OP_0x36();
     //LD A,n
     int OP_0x0A();
     int OP_0x1A();
     int OP_0xFA();
-    int OP_0x3E();
     //LD n,A
-    int OP_0x47();
-    int OP_0x4F();
-    int OP_0x57();
-    int OP_0x5F();
-    int OP_0x67();
-    int OP_0x6F();
     int OP_0x02();
     int OP_0x12();
-    int OP_0x77();
     int OP_0xEA();
     //LD A,(C)
     int OP_0xF2();
     //LD (C),A
     int OP_0xE2();
-    //LD A,(HLD)
     //LD A,(HL-)
-    //LDD A,(HL)
     int OP_0x3A();
-    //LD (HLD),A
     //LD (HL-),A
-    //LDD (HL),A
     int OP_0x32();
-    //LD A,(HLI)
     //LD A,(HL+)
-    //LDI A,(HL)
     int OP_0x2A();
-    //LD (HLI),A
     //LD (HL+),A
-    //LDI (HL),A
     int OP_0x22();
     //LDH (n),A
     int OP_0xE0();

--- a/src/inc/cpu.h
+++ b/src/inc/cpu.h
@@ -23,15 +23,9 @@ private:
 
     using opcodeFnPtr = int(CPU::*)();
     using opcodeFnPtr2 = int(CPU::*)(const byte_t&);
-    using preCB0x40_FunctionPtr = void(CPU::*)(byte_t&);
-    using postCB0x40_FunctionPtr = void(CPU::*)(byte_t&, int);
-
     opcodeFnPtr instructionTable[c_INSTRUCTION_TABLE_SIZE]{};
     opcodeFnPtr2 instructionTable2[c_INSTRUCTION_TABLE_SIZE]{};
-
-    preCB0x40_FunctionPtr preCB0x40_FunctionTable[(0x40)]{};
-    postCB0x40_FunctionPtr postCB0x40_FunctionTable[(0xFF-0x40)]{};
-
+    
 public:
     CPU();
     void frameUpdate();
@@ -59,6 +53,7 @@ private:
     word_t pop();
 
     byte_t& getRegister(int index);
+    std::string_view getRegisterStr(int index);
     int opcode_Translator(byte_t opcode);
     int cpu_restart(const byte_t& opcode);
     int cpu_byteLoad(const byte_t& opcode);
@@ -76,18 +71,14 @@ private:
     //Jumps
     enum class JumpTest 
     {
-        NotZero,
-        Zero,
-        NotCarry,
-        Carry,
-        Always
+        NotZero, Zero, NotCarry,
+        Carry, Always,
     };
     bool testJumpTest(JumpTest type);
     void jump(JumpTest type, const word_t& address);
     void jumpRelative(JumpTest type, const byte_t& unsignedData);
     void call(JumpTest type, const word_t& address);
     void return_(JumpTest type);
-    void restart(byte_t address);
     void checkDAA(byte_t& byte);
     void byteINC(byte_t& target); //increment
     void byteDEC(byte_t& target); //decrement
@@ -102,14 +93,14 @@ private:
     void testBit_OP(byte_t& byte, int bit);
     void resetBit(byte_t& byte, int bit);
     void setBit(byte_t& byte, int bit);
-    void swapNibbles(byte_t& reg);
-    void leftRotate(byte_t& byte);
-    void leftRotateWithCarry(byte_t& byte);
-    void rightRotate(byte_t& byte);
-    void rightRotateWithCarry(byte_t& byte);
-    void leftShift(byte_t& byte);
-    void rightShift(byte_t& byte);
-    void rightShiftArithmetic(byte_t& byte);
+    void swapNibbles(byte_t& reg, int);
+    void leftRotate(byte_t& byte, int);
+    void leftRotateWithCarry(byte_t& byte, int);
+    void rightRotate(byte_t& byte, int);
+    void rightRotateWithCarry(byte_t& byte, int);
+    void leftShift(byte_t& byte, int);
+    void rightShift(byte_t& byte, int);
+    void rightShiftArithmetic(byte_t& byte, int);
     
 
     int OP_NOT_IMPLEMTED();

--- a/src/inc/cpu.h
+++ b/src/inc/cpu.h
@@ -70,11 +70,15 @@ private:
     void byteOR(const byte_t& data);
     void byteXOR(const byte_t& data);
     void byteCP(const byte_t& data); //compare
-
     void checkDAA(byte_t& byte);
-    void byteINC(byte_t& target); //increment
-    void byteDEC(byte_t& target); //decrement
-    
+
+    int cpu_byteInc(const byte_t& opcode);
+    int cpu_byteDec(const byte_t& opcode);
+    void byteINC(byte_t& target); 
+    void byteDEC(byte_t& target); 
+
+    void wordAdd(word_t& reg, const word_t& addValue);
+
     //Jumps
     enum class JumpTest 
     {
@@ -85,10 +89,6 @@ private:
     void jump(JumpTest type, const word_t& address);
     void call(JumpTest type, const word_t& address);
     void return_(JumpTest type);
-    
-    
-    //Word Arithmetic
-    void wordAdd(word_t& reg, const word_t& addValue);
 
     //CB commands
     int CBopcode_Translator(byte_t opcode);
@@ -159,26 +159,6 @@ private:
     int OP_0xC1();
     int OP_0xD1();
     int OP_0xE1();
-    
-    //INC n
-    int OP_0x3C();
-    int OP_0x04();
-    int OP_0x0C();
-    int OP_0x14();
-    int OP_0x1C();
-    int OP_0x24();
-    int OP_0x2C();
-    int OP_0x34();
-    //DEC n
-    int OP_0x3D();
-    int OP_0x05();
-    int OP_0x0D();
-    int OP_0x15();
-    int OP_0x1D();
-    int OP_0x25();
-    int OP_0x2D();
-    int OP_0x35();
-
     //Word arithmatic
     //ADD HL,n
     int OP_0x09();

--- a/src/inc/cpu.h
+++ b/src/inc/cpu.h
@@ -22,12 +22,15 @@ private:
     bool m_lineByLine{};
 
     using opcodeFnPtr = int(CPU::*)();
-    using preCB0x40_Function = void(CPU::*)(byte_t&);
-    using postCB0x40_Function = void(CPU::*)(byte_t&, int);
+    using opcodeFnPtr2 = int(CPU::*)(const byte_t&);
+    using preCB0x40_FunctionPtr = void(CPU::*)(byte_t&);
+    using postCB0x40_FunctionPtr = void(CPU::*)(byte_t&, int);
 
     opcodeFnPtr instructionTable[c_INSTRUCTION_TABLE_SIZE]{};
-    preCB0x40_Function preCB0x40_FunctionTable[(0x40)]{};
-    postCB0x40_Function postCB0x40_FunctionTable[(0xFF-0x40)]{};
+    opcodeFnPtr2 instructionTable2[c_INSTRUCTION_TABLE_SIZE]{};
+
+    preCB0x40_FunctionPtr preCB0x40_FunctionTable[(0x40)]{};
+    postCB0x40_FunctionPtr postCB0x40_FunctionTable[(0xFF-0x40)]{};
 
 public:
     CPU();
@@ -56,8 +59,22 @@ private:
     word_t pop();
     void checkDAA(byte_t& byte);
     
+
+    byte_t& getRegister(int index);
+    int opcode_Translator(byte_t opcode);
+
+    int cpu_byteArithmetic(const byte_t& opcode);
+    void byteAdd(const byte_t& data);
+    void byteAddWithCarry(const byte_t& data);
+    void byteSub(const byte_t& data);
+    void byteSubWithCarry(const byte_t& data);
+    void byteAND(const byte_t& data);
+    void byteOR(const byte_t& data);
+    void byteXOR(const byte_t& data);
+    void byteCP(const byte_t& data); //compare
+
+
     //CB commands
-    byte_t& CBopcodeToRegister(byte_t opcode);
     int CBopcode_Translator(byte_t opcode);
     
     bool testBit(const byte_t& byte, int bit) const;
@@ -101,23 +118,7 @@ private:
     };
     void byteLoad(ByteLoadTarget ldTarget, ByteLoadSource ldSource);
     
-    enum class WordLoadTarget
-    {
-        BC, DE, HL, SP, D16I,
-    };
-    enum class WordLoadSource
-    {
-        HL, SP, D16, SPpD8,
-    };
-    void wordLoad(WordLoadTarget ldTarget, WordLoadSource ldSource);
 
-    //Byte Arithmetic
-    void byteAdd(byte_t& reg, const byte_t& addValue, bool withCarry=false);
-    void byteSub(byte_t& reg, const byte_t& subValue, bool withCarry=false);
-    void byteAND(byte_t& reg, const byte_t& andValue);
-    void byteOR(byte_t& reg, const byte_t& orValue);
-    void byteXOR(byte_t& reg, const byte_t& xorValue);
-    void byteCP(const byte_t& reg, const byte_t& cmpValue); //compare
     void byteINC(byte_t& target); //increment
     void byteDEC(byte_t& target); //decrement
     //Word Arithmetic
@@ -125,6 +126,7 @@ private:
 
     //Opcodes
     int OP_NOT_IMPLEMTED();
+    int OP_NOT_IMPLEMTED2(const byte_t&);
     //byte Loads
     //LD nn,n
     int OP_0x06();
@@ -256,87 +258,6 @@ private:
     int OP_0xD1();
     int OP_0xE1();
     
-    //Byte arithmetic with reg A
-    //ADD A,n
-    int OP_0x87();
-    int OP_0x80();
-    int OP_0x81();
-    int OP_0x82();
-    int OP_0x83();
-    int OP_0x84();
-    int OP_0x85();
-    int OP_0x86();
-    int OP_0xC6();
-    //ADC A,n
-    int OP_0x8F();
-    int OP_0x88();
-    int OP_0x89();
-    int OP_0x8A();
-    int OP_0x8B();
-    int OP_0x8C();
-    int OP_0x8D();
-    int OP_0x8E();
-    int OP_0xCE();
-    //SUB A, n
-    int OP_0x97();
-    int OP_0x90();
-    int OP_0x91();
-    int OP_0x92();
-    int OP_0x93();
-    int OP_0x94();
-    int OP_0x95();
-    int OP_0x96();
-    int OP_0xD6();
-    //SBC A,n
-    int OP_0x9F();
-    int OP_0x98();
-    int OP_0x99();
-    int OP_0x9A();
-    int OP_0x9B();
-    int OP_0x9C();
-    int OP_0x9D();
-    int OP_0x9E();
-    // int OP_0x??(); rip D8
-    //AND A, n
-    int OP_0xA7();
-    int OP_0xA0();
-    int OP_0xA1();
-    int OP_0xA2();
-    int OP_0xA3();
-    int OP_0xA4();
-    int OP_0xA5();
-    int OP_0xA6();
-    int OP_0xE6();
-    //OR A, n
-    int OP_0xB7();
-    int OP_0xB0();
-    int OP_0xB1();
-    int OP_0xB2();
-    int OP_0xB3();
-    int OP_0xB4();
-    int OP_0xB5();
-    int OP_0xB6();
-    int OP_0xF6();
-    //XOR A, n
-    int OP_0xAF();
-    int OP_0xA8();
-    int OP_0xA9();
-    int OP_0xAA();
-    int OP_0xAB();
-    int OP_0xAC();
-    int OP_0xAD();
-    int OP_0xAE();
-    int OP_0xEE();
-    //CP A, n
-    int OP_0xBF();
-    int OP_0xB8();
-    int OP_0xB9();
-    int OP_0xBA();
-    int OP_0xBB();
-    int OP_0xBC();
-    int OP_0xBD();
-    int OP_0xBE();
-    int OP_0xFE();
     //INC n
     int OP_0x3C();
     int OP_0x04();

--- a/src/inc/cpu.h
+++ b/src/inc/cpu.h
@@ -18,7 +18,7 @@ private:
     word_t m_SP{};
     
     bool m_InteruptsEnabled{};
-    bool halted{};
+    bool m_Halted{};
     bool m_lineByLine{};
 
     using opcodeFnPtr = int(CPU::*)();


### PR DESCRIPTION
Generalisable opcodes, like LD, or arithmetic were updated to work off via a function which translates the opcode, instead of an individual function for each opcode. Also allowed added comments with the appropriate assembly to those functions. Additionally cleaned up the way CB opcodes were translated. 